### PR TITLE
Removed the sort method on _technical

### DIFF
--- a/objects/data/AlphaVantage.js
+++ b/objects/data/AlphaVantage.js
@@ -299,7 +299,7 @@ class AlphaVantage {
 					array.push(newObject);
 				}
 			}
-			return _.sortBy(array, 'date');
+			return array;
 		})
 	}
 


### PR DESCRIPTION
Looks like all of the technical indicators are returning their arrays in reverse order. This is due to the lodash sort being performed on the array just before being returned. Remove this and it's all good.