### PR TITLE
Fix crash when stopping Stream if IEX wasn't enabled

### DIFF
--- a/objects/data/Stream.js
+++ b/objects/data/Stream.js
@@ -111,7 +111,9 @@ class Stream extends EventEmitter {
 	 */
 	stop() {
 		this.request.abort();
-		this.socket.disconnect();
+		if(this.iex){
+			this.socket.disconnect();
+		}
 	}
 
 	_createQuote(input) {


### PR DESCRIPTION
The following line in the current code is problematic:
https://github.com/Ladinn/algotrader/blob/492b9fa4732a0bbba74313733c4db1711bb838ce/objects/data/Stream.js#L114

This is because, unless the Stream object was created with `iex` enabled, the socket will not be initialized, as shown:
https://github.com/Ladinn/algotrader/blob/492b9fa4732a0bbba74313733c4db1711bb838ce/objects/data/Stream.js#L98-L106

This PR checks to see if `this.iex` is set before attempting to disconnect the socket, preventing the crash.